### PR TITLE
Better error handling for capistrano deployment script

### DIFF
--- a/lib/flowdock/capistrano.rb
+++ b/lib/flowdock/capistrano.rb
@@ -12,24 +12,41 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
 
     task :save_deployed_branch do
-      run "echo '#{source.head}' > #{current_path}/BRANCH"
+      begin
+        run "echo '#{source.head}' > #{current_path}/BRANCH"
+      rescue => e
+        puts "Flowdock: error in saving deployed branch information: " + e
+      end
     end
 
     task :set_flowdock_api do
       set :rails_env, variables.include?(:stage) ? stage : ENV['RAILS_ENV']
-      set :repo, Grit::Repo.new(".")
-      config = Grit::Config.new(repo)
-      set :flowdock_api, Flowdock::Flow.new(:api_token => flowdock_api_token, 
-        :source => "Capistrano deployment", :project => flowdock_project_name,
-        :from => {:name => config["user.name"], :address => config["user.email"]})
+      begin
+        set :repo, Grit::Repo.new(".")
+        config = Grit::Config.new(repo)
+      rescue => e
+        puts "Flowdock: error in fetching your git repository information: " + e
+      end
+
+      begin
+        set :flowdock_api, Flowdock::Flow.new(:api_token => flowdock_api_token,
+          :source => "Capistrano deployment", :project => flowdock_project_name,
+          :from => {:name => config["user.name"], :address => config["user.email"]})
+      rescue => e
+        puts "Flowdock: error in configuring Flowdock API: " + e
+      end
     end
 
     task :notify_deploy_finished do
       # send message to the flow
-      flowdock_api.send_message(:format => "html", 
-        :subject => "#{flowdock_project_name} deployed with branch #{branch} on ##{rails_env}", 
-        :content => notification_message, 
-        :tags => ["deploy", "#{rails_env}"] | flowdock_deploy_tags)
+      begin
+        flowdock_api.send_message(:format => "html",
+          :subject => "#{flowdock_project_name} deployed with branch #{branch} on ##{rails_env}",
+          :content => notification_message,
+          :tags => ["deploy", "#{rails_env}"] | flowdock_deploy_tags)
+      rescue => e
+        puts "Flowdock: error in sending notification to your flow: " + e
+      end
     end
 
     def notification_message


### PR DESCRIPTION
Wrapped potentially error raising operations in capistrano notification script with begin-rescues so that a error in sending Flowdock notification would never cause failing of the entire deployment.
