### PR TITLE
Allow multiple flowdock_api_tokens for deploy notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Flowdock API Ruby Gem includes a ready task for sending deployment notificat
  # for Flowdock Gem notifications
  set :flowdock_project_name, "My project"
  set :flowdock_deploy_tags, ["frontend"]
- set :flowdock_api_token, "_YOUR_API_TOKEN_HERE_"
+ set :flowdock_api_token, ["_YOUR_API_TOKEN_HERE_"]
 ```
 
 


### PR DESCRIPTION
This change allows a deploy script to set :flowdock_api_token to an array of api tokens, in order to notify multiple chatrooms of a deploy.

It still accepts a single string, but I've updated the readme to hint at the possibility of adding more tokens.
