### PR TITLE
Unbreak current branch detection

### DIFF
--- a/lib/flowdock/capistrano.rb
+++ b/lib/flowdock/capistrano.rb
@@ -12,7 +12,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
     task :save_deployed_branch do
       begin
-        run "echo '#{source.head}' > #{current_path}/BRANCH"
+        run "echo '#{source.head.chomp}' > #{current_path}/BRANCH"
       rescue => e
         puts "Flowdock: error in saving deployed branch information: #{e.to_s}"
       end


### PR DESCRIPTION
Without this diff, capistrano writes too many characters into the BRANCH file:

```
* executing "echo 'my_branch\\\n' > /home/hlp/helpster_www/current/BRANCH"
```

With this diff, extraneous characters are removed and "branch == current_branch" works properly.
