### PR TITLE
Do not post to the flow if capitrano is in dry-run mode

### DIFF
--- a/lib/flowdock/capistrano.rb
+++ b/lib/flowdock/capistrano.rb
@@ -50,7 +50,7 @@ Capistrano::Configuration.instance(:must_exist).load do
             :subject => "#{flowdock_project_name} deployed with branch #{branch} on ##{flowdock_deploy_env}",
             :content => notification_message,
             :tags => ["deploy", "#{flowdock_deploy_env}"] | flowdock_deploy_tags)
-        end
+        end unless dry_run
       rescue => e
         puts "Flowdock: error in sending notification to your flow: #{e.to_s}"
       end


### PR DESCRIPTION
Without this diff, a successful deployment notification is sent to the flow even if Capistrano runs in dry_run mode (the `-n` flag). 
In the context of this capistrano task, `dry_run` is always defined at Capitrano's level, so this diff should never cause a deploy to abort (see https://github.com/capistrano/capistrano/blob/master/lib/capistrano/configuration.rb#L24)

I'm proposing this fix because using flowdock's Capistrano task without it can cause great confusion in a team, leading people to believe that a new version has been deployed when it was not. 
