### PR TITLE
raise specific 404 error for better error handling outside of flowdock

### DIFF
--- a/lib/flowdock.rb
+++ b/lib/flowdock.rb
@@ -17,7 +17,6 @@ module Flowdock
     def handle_response(resp)
       json = MultiJson.decode(resp.body || '{}')
 
-      puts resp.code
       if resp.code == 404
         raise NotFoundError, "Flowdock API returned error:\nStatus: #{resp.code}\n Message: #{json["message"]}"
       end

--- a/lib/flowdock.rb
+++ b/lib/flowdock.rb
@@ -6,6 +6,7 @@ module Flowdock
   FLOWDOCK_API_URL = "https://api.flowdock.com/v1"
 
   class InvalidParameterError < StandardError; end
+  class NotFoundError < StandardError; end
   class ApiError < StandardError; end
 
   module Helpers
@@ -15,6 +16,12 @@ module Flowdock
 
     def handle_response(resp)
       json = MultiJson.decode(resp.body || '{}')
+
+      puts resp.code
+      if resp.code == 404
+        raise NotFoundError, "Flowdock API returned error:\nStatus: #{resp.code}\n Message: #{json["message"]}"
+      end
+
       unless resp.code >= 200 && resp.code < 300
         errors = json["errors"].map {|k,v| "#{k}: #{v.join(',')}"}.join("\n") unless json["errors"].nil?
         raise ApiError, "Flowdock API returned error:\nStatus: #{resp.code}\n Message: #{json["message"]}\n Errors:\n#{errors}"

--- a/spec/flowdock_spec.rb
+++ b/spec/flowdock_spec.rb
@@ -224,6 +224,25 @@ describe Flowdock do
         @flow.push_to_team_inbox(:subject => "Hello World", :content => @example_content).should be_false
       }.should raise_error(Flowdock::ApiError)
     end
+
+    it "should raise error if backend returns 404 NotFound" do
+      lambda {
+        stub_request(:post, push_to_team_inbox_url(@token)).
+          with(:body => {
+            :source => "myapp",
+            :project => "myproject",
+            :format => "html",
+            :from_name => "Eric Example",
+            :from_address => "eric@example.com",
+            :reply_to => "john@example.com",
+            :subject => "Hello World",
+            :content => @example_content
+          }).
+          to_return(:body => "{}", :status => 404)
+
+        @flow.push_to_team_inbox(:subject => "Hello World", :content => @example_content).should be_false
+      }.should raise_error(Flowdock::NotFoundError)
+    end
   end
 
   describe "with sending Chat messages" do


### PR DESCRIPTION
hey,

we have a lot of customers at Codeship that integrate with Flowdock. from time to time it happens people don't update the Flowdock configuration on Codeship and we get a lot of 404 errors.

this new exception type allows us to handle the case way better and we don't need to parse the error message :)

thx
ben