### PR TITLE
updated response handling so that empty responses do not result in a JSON parsing error

### DIFF
--- a/lib/flowdock.rb
+++ b/lib/flowdock.rb
@@ -15,7 +15,9 @@ module Flowdock
     end
 
     def handle_response(resp)
-      json = MultiJson.decode(resp.body || '{}')
+      body = (resp.body.nil? || resp.body.strip.empty?) ? '{}' : resp.body
+
+      json = MultiJson.decode(body)
 
       if resp.code == 404
         raise NotFoundError, "Flowdock API returned error:\nStatus: #{resp.code}\n Message: #{json["message"]}"

--- a/spec/flowdock_spec.rb
+++ b/spec/flowdock_spec.rb
@@ -21,6 +21,25 @@ describe Flowdock do
     end
   end
 
+  describe "handle_response" do
+    it "parses a response body that contains an empty string" do
+      class TestResponse
+        attr_reader :body, :code
+
+        def initialize
+          @body = ""
+          @code = 200
+        end
+      end
+
+      class TestHelper
+        include Flowdock::Helpers
+      end
+
+      expect(TestHelper.new.handle_response(TestResponse.new)).to eq({})
+    end
+  end
+
   describe "with sending Team Inbox messages" do
     before(:each) do
       @token = "test"


### PR DESCRIPTION
we've updated the response handling so that empty response bodies no longer result in an error. The old code intended to handle this, but it didn't, and there was no test. So we added a test as well.